### PR TITLE
update releases.yaml for 22.04.1

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -12,7 +12,7 @@ lts:
   slug: JammyJellyfish
   name: "Jammy Jellyfish"
   short_version: "22.04"
-  full_version: "22.04"
+  full_version: "22.04.1"
   release_date: "April 2022"
   eol: "April 2027"
   release_notes_url: "https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668"
@@ -31,28 +31,28 @@ openstack_lts:
 
 checksums:
   desktop:
-    "22.04": "b85286d9855f549ed9895763519f6a295a7698fb9c5c5345811b3eefadfb6f07 *ubuntu-22.04-desktop-amd64.iso"
+    "22.04.1": "c396e956a9f52c418397867d1ea5c0cf1a99a49dcf648b086d2fb762330cc88d *ubuntu-22.04.1-desktop-amd64.iso"
     "21.10": "f8d3ab0faeaecb5d26628ae1aa21c9a13e0a242c381aa08157db8624d574b830 *ubuntu-21.10-desktop-amd64.iso"
     "20.04.4": "f92f7dca5bb6690e1af0052687ead49376281c7b64fbe4179cc44025965b7d1c *ubuntu-20.04.4-desktop-amd64.iso"
   live-server:
-    "22.04": "84aeaf7823c8c61baa0ae862d0a06b03409394800000b3235854a6b38eb4856f *ubuntu-22.04-live-server-amd64.iso"
+    "22.04.1": "10f19c5b2b8d6db711582e0e27f5116296c34fe4b313ba45f9b201a5007056cb *ubuntu-22.04.1-live-server-amd64.iso"
     "21.10": "e84f546dfc6743f24e8b1e15db9cc2d2c698ec57d9adfb852971772d1ce692d4 *ubuntu-21.10-live-server-amd64.iso"
     "20.04.4": "28ccdb56450e643bad03bb7bcf7507ce3d8d90e8bf09e38f6bd9ac298a98eaad *ubuntu-20.04.4-live-server-amd64.iso"
     "18.04.6": "6c647b1ab4318e8c560d5748f908e108be654bad1e165f7cf4f3c1fc43995934 *ubuntu-18.04.6-live-server-amd64.iso"
   desktop-arm64+raspi:
-    "22.04": "75d05ef58e527b36ffb7807eae23d6b63cc80adaf59fff95c39f4077647a6423 *ubuntu-22.04-preinstalled-desktop-arm64+raspi.img.xz"
+    "22.04.1": "680c2c1770b53d90e825fd9a40178f605af47acfff681ad5f68d38094d1c32eb *ubuntu-22.04.1-preinstalled-desktop-arm64+raspi.img.xz"
     "21.10": "5187d507099f26bc4d8218085109af498fae5ff93b40c668f83bab5c7574d954 *ubuntu-21.10-preinstalled-desktop-arm64+raspi.img.xz"
     "21.04": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
-    "22.04": "9cd6b5e6b4e4a7453cfde276927efe20380ab9ec0377318d5ce0bc8c8a56993b *ubuntu-22.04-preinstalled-server-arm64+raspi.img.xz"
+    "22.04.1": "5d0661eef1a0b89358159f3849c8f291be2305e5fe85b7a16811719e6e8ad5d1 *ubuntu-22.04.1-preinstalled-server-arm64+raspi.img.xz"
     "21.10": "126f940d3b270a6c1fc5a183ac8a3d193805fead4f517296a7df9d3e7d691a03 *ubuntu-21.10-preinstalled-server-arm64+raspi.img.xz"
     "20.04.4": "6aeba20c00ef13ee7b48c57217ad0d6fc3b127b3734c113981d9477aceb4dad7 *ubuntu-20.04.4-preinstalled-server-arm64+raspi.img.xz"
   server-armhf+raspi:
-    "22.04": "d93bc4b7f4040c04e17ca44e61f1e08aa8fb9086671b4065b8722e2b5dd6543e *ubuntu-22.04-preinstalled-server-armhf+raspi.img.xz"
+    "22.04.1": "342fb581ce11208c26f35675acafdc3d56ac2838b1297a508e602f88606903f1 *ubuntu-22.04.1-preinstalled-server-armhf+raspi.img.xz"
     "21.10": "341593c9607ed20744cd86941d94d73e3ba4f74e8ef2633eec63ce9b0cfac5a1 *ubuntu-21.10-preinstalled-server-armhf+raspi.img.xz"
     "20.04.4": "3b1704e8e4ff8e01dd89b9dd6adf9b99b48b2a7530d6f7676ce8c37772ff4178 *ubuntu-20.04.4-preinstalled-server-armhf+raspi.img.xz"
   server-riscv64:
-    "22.04": "e485892116d19d979967ab0873c78528b7d5c4636284428f51b26f0c0d8a7c3c *ubuntu-22.04-preinstalled-server-riscv64+unmatched.img.xz"
+    "22.04.1": "a4cf79456e09c7c03c96ef4b0924dd54ab1706d86af09d29a7c117855e80eac6 *ubuntu-22.04.1-preinstalled-server-riscv64+unmatched.img.xz"
     "21.10": "8067892fa627eb219b31dc629f31f3bda6b015dfeabf2fdc9b0ed150bf7984b8 *ubuntu-21.10-preinstalled-server-riscv64+unmatched.img.xz"
   core-20-arm64+raspi:
     "20": "6a6f0dc12c4670d608fc9ca8ae3550167f129c6a1a027e638548bee1b4f8b238 *ubuntu-core-20-arm64+raspi.img.xz"


### PR DESCRIPTION
## Done

:warning: the download links will not work yet, do not merge :warning:

- updated releases.yaml with the checksums for 22.04.1


## QA

- Check out this feature branch
- Run the site using the command ./run serve or dotrun
- View the site locally in your web browser at:
  - http://0.0.0.0:8012/download
- See that the desktop and server download CTAs point to 22.04.1

## Issue / Card

Fixes https://github.com/canonical/jp.ubuntu.com/issues/415
