### PR TITLE
Increase no. workers and separate blog to reduce sentry errors

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-  "directory": "static/components/"
-}
-

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,10 @@
 cache.sqlite
 README.md
 HACKING.md
+.eslintignore
+.eslintrc.js
+.prettierrc
+.stylelintrc
 
 # The run script isn't needed
 run

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ bower_components/
 vendor/
 # Normally lockfiles would be committed, but we use yarn instead of NPM for locking dependencies
 package-lock.json
+.dotrun.json
 
 # [build] Built files
 /build/

--- a/entrypoint
+++ b/entrypoint
@@ -2,7 +2,7 @@
 
 set -e
 
-RUN_COMMAND="talisker.gunicorn.gevent webapp.app:app --bind $1 --worker-class gevent --name talisker-`hostname`"
+RUN_COMMAND="talisker.gunicorn.gevent webapp.app:app --bind $1 --workers 2 --worker-class gevent --name talisker-`hostname`"
 
 if [ "${FLASK_DEBUG}" = true ] || [ "${FLASK_DEBUG}" = 1 ]; then
     RUN_COMMAND="${RUN_COMMAND} --reload --log-level debug --timeout 9999"

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -18,17 +18,58 @@ env:
       key: ubuntu-api-username
       name: discourse-api
 
-readinessPath: "/"
-
 # Overrides for production
 production:
   replicas: 5
+  routes:
+    - paths: [/blog]
+      name: jp-ubuntu-com-blog
+      app_name: jp.ubuntu.com-blog
+      image: prod-comms.docker-registry.canonical.com/jp.ubuntu.com
+      replicas: 3
+      memoryLimit: 256Mi
+      env:
+        - name: DISCOURSE_API_KEY
+          secretKeyRef:
+            key: ubuntu-api-key
+            name: discourse-api
+
+        - name: DISCOURSE_API_USERNAME
+          secretKeyRef:
+            key: ubuntu-api-username
+            name: discourse-api
+
+        - name: SENTRY_DSN
+          value: https://5d270c51e9a946b6ae1bb0155498738d@sentry.is.canonical.com//12
+
   nginxConfigurationSnippet: |
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";
+  
 
 # Overrides for staging
 staging:
   replicas: 3
+  routes:
+    - paths: [/blog]
+      name: jp-ubuntu-com-blog
+      app_name: jp.ubuntu.com-blog
+      image: prod-comms.docker-registry.canonical.com/jp.ubuntu.com
+      replicas: 3
+      memoryLimit: 256Mi
+      env:
+        - name: DISCOURSE_API_KEY
+          secretKeyRef:
+            key: ubuntu-api-key
+            name: discourse-api
+
+        - name: DISCOURSE_API_USERNAME
+          secretKeyRef:
+            key: ubuntu-api-username
+            name: discourse-api
+
+        - name: SENTRY_DSN
+          value: https://5d270c51e9a946b6ae1bb0155498738d@sentry.is.canonical.com//12
+
   nginxConfigurationSnippet: |
     more_set_headers "X-Robots-Tag: noindex";
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";


### PR DESCRIPTION
## Done

The main [two sentry errors](https://sentry.is.canonical.com/canonical/jp-ubuntu-com/) we get are worker timeouts and blog going 503, this PR should reduce the number of such occurences.

- Worker increased to 2 based on https://github.com/canonical/ubuntu.com/pull/11212
- Separated /blog into a different service, based on https://github.com/canonical/canonical.com/pull/599/files
- Did some cleanup on unused files and files that we don't need in the building process.

## QA

Check that https://jp-ubuntu-com-418.demos.haus/blog works as usual

## Issue / Card

Fix https://github.com/canonical/jp.ubuntu.com/issues/417

