### PR TITLE
Updates for 22.10 release

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1,27 +1,27 @@
 latest:
-  slug: ImpishIndri
-  name: "Impish Indri"
-  short_version: "21.10"
-  full_version: "21.10"
-  core_version: "20"
-  release_date: "October 2021"
-  eol: "July 2022"
+  slug: KineticKudu
+  name: "Kinetic Kudu"
+  short_version: "22.10"
+  full_version: "22.10"
+  core_version: "22"
+  release_date: "October 2022"
+  eol: "2023年7月"
   past_eol_date: false
-  release_notes_url: "https://discourse.ubuntu.com/t/impish-indri-release-notes/21951"
+  release_notes_url: "https://discourse.ubuntu.com/t/kinetic-kudu-release-notes/27976"
 lts:
   slug: JammyJellyfish
   name: "Jammy Jellyfish"
   short_version: "22.04"
   full_version: "22.04.1"
-  release_date: "April 2022"
-  eol: "April 2027"
+  release_date: "2022年4月"
+  eol: "2027年4月"
   release_notes_url: "https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668"
 previous_lts:
   name: "Focal Fossa"
   short_version: "20.04"
   full_version: "20.04.4"
-  release_date: "April 2020"
-  eol: "April 2025"
+  release_date: "2020年4月"
+  eol: "2025年4月"
 previous_previous_lts:
   name: "Bionic Beaver"
   short_version: "18.04"
@@ -31,27 +31,33 @@ openstack_lts:
 
 checksums:
   desktop:
+    "22.10": "b98f13cd86839e70cb7757d46840230496b3febea309dd73bd5f81383474e47b *ubuntu-22.10-desktop-amd64.iso"
     "22.04.1": "c396e956a9f52c418397867d1ea5c0cf1a99a49dcf648b086d2fb762330cc88d *ubuntu-22.04.1-desktop-amd64.iso"
     "21.10": "f8d3ab0faeaecb5d26628ae1aa21c9a13e0a242c381aa08157db8624d574b830 *ubuntu-21.10-desktop-amd64.iso"
     "20.04.4": "f92f7dca5bb6690e1af0052687ead49376281c7b64fbe4179cc44025965b7d1c *ubuntu-20.04.4-desktop-amd64.iso"
   live-server:
+    "22.10": "874452797430a94ca240c95d8503035aa145bd03ef7d84f9b23b78f3c5099aed *ubuntu-22.10-live-server-amd64.iso"
     "22.04.1": "10f19c5b2b8d6db711582e0e27f5116296c34fe4b313ba45f9b201a5007056cb *ubuntu-22.04.1-live-server-amd64.iso"
     "21.10": "e84f546dfc6743f24e8b1e15db9cc2d2c698ec57d9adfb852971772d1ce692d4 *ubuntu-21.10-live-server-amd64.iso"
     "20.04.4": "28ccdb56450e643bad03bb7bcf7507ce3d8d90e8bf09e38f6bd9ac298a98eaad *ubuntu-20.04.4-live-server-amd64.iso"
     "18.04.6": "6c647b1ab4318e8c560d5748f908e108be654bad1e165f7cf4f3c1fc43995934 *ubuntu-18.04.6-live-server-amd64.iso"
   desktop-arm64+raspi:
+    "22.10": "c9cf57399a5e3e3a9803740f8107ef52891b7d3ac293106d3257396b75ddf7de *ubuntu-22.10-preinstalled-desktop-arm64+raspi.img.xz"
     "22.04.1": "680c2c1770b53d90e825fd9a40178f605af47acfff681ad5f68d38094d1c32eb *ubuntu-22.04.1-preinstalled-desktop-arm64+raspi.img.xz"
     "21.10": "5187d507099f26bc4d8218085109af498fae5ff93b40c668f83bab5c7574d954 *ubuntu-21.10-preinstalled-desktop-arm64+raspi.img.xz"
     "21.04": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
+    "22.10": "170d860a49039499d349eeb69276c997e26ada811f5b4bce761b55a6461914a2 *ubuntu-22.10-preinstalled-server-arm64+raspi.img.xz"
     "22.04.1": "5d0661eef1a0b89358159f3849c8f291be2305e5fe85b7a16811719e6e8ad5d1 *ubuntu-22.04.1-preinstalled-server-arm64+raspi.img.xz"
     "21.10": "126f940d3b270a6c1fc5a183ac8a3d193805fead4f517296a7df9d3e7d691a03 *ubuntu-21.10-preinstalled-server-arm64+raspi.img.xz"
     "20.04.4": "6aeba20c00ef13ee7b48c57217ad0d6fc3b127b3734c113981d9477aceb4dad7 *ubuntu-20.04.4-preinstalled-server-arm64+raspi.img.xz"
   server-armhf+raspi:
+    "22.10": "a869ade13fb1a983da95eb92093e640692a930d01354d63f05571234ca0cd6b5 *ubuntu-22.10-preinstalled-server-armhf+raspi.img.xz"
     "22.04.1": "342fb581ce11208c26f35675acafdc3d56ac2838b1297a508e602f88606903f1 *ubuntu-22.04.1-preinstalled-server-armhf+raspi.img.xz"
     "21.10": "341593c9607ed20744cd86941d94d73e3ba4f74e8ef2633eec63ce9b0cfac5a1 *ubuntu-21.10-preinstalled-server-armhf+raspi.img.xz"
     "20.04.4": "3b1704e8e4ff8e01dd89b9dd6adf9b99b48b2a7530d6f7676ce8c37772ff4178 *ubuntu-20.04.4-preinstalled-server-armhf+raspi.img.xz"
   server-riscv64:
+    "22.10": "858feb7f96e94ad904624262ee4a669caebafd012a2812e19e0dd21be9b6faa6 *ubuntu-22.10-preinstalled-server-riscv64+unmatched.img.xz"
     "22.04.1": "a4cf79456e09c7c03c96ef4b0924dd54ab1706d86af09d29a7c117855e80eac6 *ubuntu-22.04.1-preinstalled-server-riscv64+unmatched.img.xz"
     "21.10": "8067892fa627eb219b31dc629f31f3bda6b015dfeabf2fdc9b0ed150bf7984b8 *ubuntu-21.10-preinstalled-server-riscv64+unmatched.img.xz"
   core-20-arm64+raspi:

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -24,7 +24,7 @@
       title=takeover['title'],
       subtitle=takeover['subtitle'],
       class="p-takeover--" + takeover['class'],
-      header_image=takeover['image'],
+      header_image=takeover['header_image'],
       image_style="width: " + takeover['image_width'] + "px; height: " + takeover['image_height'] + "px; ",
       image_hide_small="true",
       primary_url=takeover['primary_url'],


### PR DESCRIPTION
## Done

Upates for 22.10 release

## QA

Go to /download page and check that the new 22.10 version shows up

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12211

## Screenshots

