### PR TITLE
Add GA events for take over impressions

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -254,6 +254,14 @@
       } else {
           secondaryUrl.remove();
       }
+
+      dataLayer.push({
+        event: "NonInteractiveGAEvent",
+        eventCategory: "jp.ubuntu.com-impression-takeover",
+        eventAction: "CTA click",
+        eventLabel: selectedTakeover.title,
+        eventValue: undefined,
+      });
     }
   </script>
 


### PR DESCRIPTION
## Done

Add GA events for take over impressions

## QA

- Load the homepage (make sure a takeover loads) and check the ga event has been pushed with the appropriate data
Two ways to do this:
1. run the branch locally follow the guide in the [google analytic docs](https://developers.google.com/analytics/devguides/collection/analyticsjs/events) to see tga events in the network tab
2. (Recommended) Download a broswer extension that tracks GA events, I am using [tag legacy](https://chrome.google.com/webstore/detail/tag-assistant-legacy-by-g/kejbdjndbnbjgmefkgdddjlbokphdefk)

## Issue / Card

https://warthogs.atlassian.net/browse/WD-2463