### PR TITLE
Fix date formatting for EOL in each releases (#458)

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -50,7 +50,7 @@
     <div class="col-6 p-card">
       <h3 class="p-card__title">Ubuntu Desktop {{ releases.lts.full_version }} LTS</h3>
       <div class="p-card__content">
-        <p>デスクトップPCおよびノートPC向けUbuntu LTS版の最新バージョンをダウンロードいただけます。LTSはlong-term support（長期サポート）の略称です。{{ releases.lts.eol }}年 4 月までの5 年間、無料のセキュリティアップデートおよびメンテナンスアップデートが保証されています。</p>
+        <p>デスクトップPCおよびノートPC向けUbuntu LTS版の最新バージョンをダウンロードいただけます。LTSはlong-term support（長期サポート）の略称です。{{ releases.lts.eol }}までの5 年間、無料のセキュリティアップデートおよびメンテナンスアップデートが保証されています。</p>
         <p><a class="p-button--positive row" href="/download/thank-you?version={{ releases.lts.full_version }}&architecture=amd64&platform=desktop"><span class="p-link--external">ダウンロード</span></a></p>
         <p><a class="p-link--external" href="{{ releases.lts.release_notes_url }}">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
       </div>
@@ -59,7 +59,7 @@
     <div class="col-6 p-card">
       <h3 class="p-card__title">Ubuntu Desktop {{ releases.latest.full_version }}</h3>
       <div class="p-card__content">
-        <p>デスクトップPCおよびノートPC向けのUbuntuオペレーティングシステムの最新バージョンです。Ubuntu {{ releases.latest.full_version }} では、{{ releases.latest.eol }}年7月までの9か月間、セキュリティアップデートおよびメンテナンスアップデートが提供されます</p>
+        <p>デスクトップPCおよびノートPC向けのUbuntuオペレーティングシステムの最新バージョンです。Ubuntu {{ releases.latest.full_version }} では、{{ releases.latest.eol }}までの9か月間、セキュリティアップデートおよびメンテナンスアップデートが提供されます</p>
         <p><a class="p-button row" href="/download/thank-you/?version={{ releases.latest.full_version }}&architecture=amd64&platform=desktop"><span class="p-link--external">ダウンロード</span></a></p>
         <p><a class="p-link--external" href="{{ releases.latest.release_notes_url }}">Ubuntu {{ releases.latest.full_version }} release notes</a></p>
       </div>
@@ -91,7 +91,7 @@
     <div class="col-6 p-card">
       <h3 class="p-card__title">Ubuntu Server {{ releases.lts.full_version }} LTS</h3>
       <div class="p-card__content">
-        <p>Ubuntu ServerのLTS版には、OpenStackの{{ releases.openstack_lts.slug }}リリースが含まれ、{{ releases.lts.eol }}年4月までのサポートが保証されています。64ビット版のみの提供です。</p>
+        <p>Ubuntu ServerのLTS版には、OpenStackの{{ releases.openstack_lts.slug }}リリースが含まれ、{{ releases.lts.eol }}までのサポートが保証されています。64ビット版のみの提供です。</p>
         <p><a class="p-button--positive row" href="/download/thank-you?version={{ releases.lts.full_version }}&architecture=amd64&platform=live-server"><span class="p-link--external">ダウンロード</span></a></p>
         <p><a class="p-link--external" href="{{ releases.lts.release_notes_url }}">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
       </div>
@@ -100,7 +100,7 @@
     <div class="col-6 p-card">
       <h3 class="p-card__title">Ubuntu Server {{ releases.latest.full_version }}</h3>
       <div class="p-card__content">
-        <p>Ubuntu Serverの最新バージョンです。2020年7月までの9か月のセキュリティアップデートとメンテナンスアップデートが含まれます。</p>
+        <p>Ubuntu Serverの最新バージョンです。{{ releases.latest.eol }}までの9か月のセキュリティアップデートとメンテナンスアップデートが含まれます。</p>
         <p><a class="p-button row" href="/download/thank-you/?version={{ releases.latest.full_version }}&architecture=amd64&platform=live-server"><span class="p-link--external">ダウンロード</span></a></p>
         <p><a class="p-link--external" href="{{ releases.latest.release_notes_url }}">Ubuntu {{ releases.latest.full_version }} release notes</a></p>
       </div>


### PR DESCRIPTION
## Done

- Remove unnecessary formatting provided by variables.
- Use releases.latest.eol for the EOL notation of 23.04 Server.

## QA

- Open download page
- Check the EOL date in each releases

## Issue / Card

- Fixes #458 

## Screenshots

![Screenshot from 2023-08-01 22-55-56](https://github.com/canonical/jp.ubuntu.com/assets/998856/f022e684-d112-4ed5-a9fd-f7c0085e9f9c)

