### PR TITLE
sync releases.yaml for 22.04.3

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -12,7 +12,7 @@ lts:
   slug: JammyJellyfish
   name: "Jammy Jellyfish"
   short_version: "22.04"
-  full_version: "22.04.2"
+  full_version: "22.04.3"
   release_date: "2022年4月"
   eol: "2027年4月"
   release_notes_url: "https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668"
@@ -32,33 +32,33 @@ openstack_lts:
 checksums:
   desktop:
     "23.04": "a8cd6ccff865e17dd136658f6388480c9a5bc57274b29f7d5bd0ed855a9281a5 *ubuntu-23.04-desktop-amd64.iso"
-    "22.04.2": "b98dac940a82b110e6265ca78d1320f1f7103861e922aa1a54e4202686e9bbd3 *ubuntu-22.04.2-desktop-amd64.iso"
+    "22.04.3": "a435f6f393dda581172490eda9f683c32e495158a780b5a1de422ee77d98e909 *ubuntu-22.04.3-desktop-amd64.iso"
     "21.10": "f8d3ab0faeaecb5d26628ae1aa21c9a13e0a242c381aa08157db8624d574b830 *ubuntu-21.10-desktop-amd64.iso"
-    "20.04.4": "f92f7dca5bb6690e1af0052687ead49376281c7b64fbe4179cc44025965b7d1c *ubuntu-20.04.4-desktop-amd64.iso"
+    "20.04.6": "510ce77afcb9537f198bc7daa0e5b503b6e67aaed68146943c231baeaab94df1 *ubuntu-20.04.6-desktop-amd64.iso"
   live-server:
     "23.04": "c7cda48494a6d7d9665964388a3fc9c824b3bef0c9ea3818a1be982bc80d346b *ubuntu-23.04-live-server-amd64.iso"
-    "22.04.2": "5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931 *ubuntu-22.04.2-live-server-amd64.iso"
+    "22.04.3": "a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd *ubuntu-22.04.3-live-server-amd64.iso"
     "21.10": "e84f546dfc6743f24e8b1e15db9cc2d2c698ec57d9adfb852971772d1ce692d4 *ubuntu-21.10-live-server-amd64.iso"
-    "20.04.4": "28ccdb56450e643bad03bb7bcf7507ce3d8d90e8bf09e38f6bd9ac298a98eaad *ubuntu-20.04.4-live-server-amd64.iso"
+    "20.04.6": "b8f31413336b9393ad5d8ef0282717b2ab19f007df2e9ed5196c13d8f9153c8b *ubuntu-20.04.6-live-server-amd64.iso"
     "18.04.6": "6c647b1ab4318e8c560d5748f908e108be654bad1e165f7cf4f3c1fc43995934 *ubuntu-18.04.6-live-server-amd64.iso"
   desktop-arm64+raspi:
     "23.04": "c851edd5d05362b7a9fe9a6e44824d89114de2c07b6f08d97ad790f0bafdc9f1 *ubuntu-23.04-preinstalled-desktop-arm64+raspi.img.xz"
-    "22.04.2": "c7d39e37455c2ff3def2b125abb046245a9e6fbf8519f711aa22485eabd3bc52 *ubuntu-22.04.2-preinstalled-desktop-arm64+raspi.img.xz"
+    "22.04.3": "d187127752ebf16201102d32c1e7fa7a17532c6b5ccf7b3b08507d0ab0e3416c *ubuntu-22.04.3-preinstalled-desktop-arm64+raspi.img.xz"
     "21.10": "5187d507099f26bc4d8218085109af498fae5ff93b40c668f83bab5c7574d954 *ubuntu-21.10-preinstalled-desktop-arm64+raspi.img.xz"
     "21.04": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
     "23.04": "cd2a99b065b98078ad2bfec428d5bb876be19c9f5aa8abb8e5dd14125bf611b8 *ubuntu-23.04-preinstalled-server-arm64+raspi.img.xz"
-    "22.04.2": "22705473ab9c1ca19012fe2d42f917218b823d1a815dabb8a240681c51d143a5 *ubuntu-22.04.2-preinstalled-server-arm64+raspi.img.xz"
+    "22.04.3": "f3842efb3be1be4243c24203bd16e335f155fdbe104b1ed8c5efc548ea478ab0 *ubuntu-22.04.3-preinstalled-server-arm64+raspi.img.xz"
     "21.10": "126f940d3b270a6c1fc5a183ac8a3d193805fead4f517296a7df9d3e7d691a03 *ubuntu-21.10-preinstalled-server-arm64+raspi.img.xz"
-    "20.04.4": "6aeba20c00ef13ee7b48c57217ad0d6fc3b127b3734c113981d9477aceb4dad7 *ubuntu-20.04.4-preinstalled-server-arm64+raspi.img.xz"
+    "20.04.5": "44b98acd3fd4379c6b194696520b6aecb2f596b601e43e9b6934c83f0aa61026 *ubuntu-20.04.5-preinstalled-server-arm64+raspi.img.xz"
   server-armhf+raspi:
     "23.04": "4d6e43707260c3653bdbc30eecd4148b6b314612b8c522de4a60d74fd3df128f *ubuntu-23.04-preinstalled-server-armhf+raspi.img.xz"
-    "22.04.2": "45b2fb10f63fa2e820d0bd34693d86a507499f6efae1f4848af6601ebfaf8745 *ubuntu-22.04.2-preinstalled-server-armhf+raspi.img.xz"
+    "22.04.3": "dbab406bfa473ebf95aa2e34e87ebf64467067ffa0478daa85c48e213b925ed6 *ubuntu-22.04.3-preinstalled-server-armhf+raspi.img.xz"
     "21.10": "341593c9607ed20744cd86941d94d73e3ba4f74e8ef2633eec63ce9b0cfac5a1 *ubuntu-21.10-preinstalled-server-armhf+raspi.img.xz"
-    "20.04.4": "3b1704e8e4ff8e01dd89b9dd6adf9b99b48b2a7530d6f7676ce8c37772ff4178 *ubuntu-20.04.4-preinstalled-server-armhf+raspi.img.xz"
+    "20.04.5": "065c41846ddf7a1c636a1aac5a7d49ebcee819b141f9d57fd586c5f84b9b7942 *ubuntu-20.04.5-preinstalled-server-armhf+raspi.img.xz"
   server-riscv64:
     "23.04": "774a679251c496426727fcab1355f41f2523845dac405bfe9814a5c4c588df14 *ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz"
-    "22.04.2": "7a31a92f6a17e497bc8d5e72b2862ed0eb6cc68ca3a4efb1893ddcbfda13e9bd *ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz"
+    "22.04.3": "b739d17a3a7f0494b2d804c5f54fd2f303ba665acf353ee3bef78825bfc7b39c *ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz"
     "21.10": "8067892fa627eb219b31dc629f31f3bda6b015dfeabf2fdc9b0ed150bf7984b8 *ubuntu-21.10-preinstalled-server-riscv64+unmatched.img.xz"
   core-22-arm64+raspi:
     "22": "374697bd7324f10ff3c00007b75ca42885aff161cbddb63b1d14bc1551e69ce2 *ubuntu-core-22-arm64+raspi.img.xz"


### PR DESCRIPTION
equivalent to
https://github.com/canonical/ubuntu.com/pull/13083

## Done

Sync changes in ubuntu.com to jp.ubuntu.com for 22.04.3.

## QA

- open the demo page
- go to `/download`
- try to download the 22.04 image and confirm it succeeds

## Screenshots

### previous

#### download page with the string "22.04.2"
![image](https://github.com/canonical/jp.ubuntu.com/assets/4356209/a6a2310a-7c5c-491a-8941-516e88c4e57a)

#### actual download - fails

![image](https://github.com/canonical/jp.ubuntu.com/assets/4356209/5cfbc19d-78f1-4500-b12b-67e14e180e5e)


### demo

#### download page with the string "22.04.3"
![image](https://github.com/canonical/jp.ubuntu.com/assets/4356209/775e3786-41ff-44c1-9622-5f9a79f7d9bc)

#### actual download - succeeds

![image](https://github.com/canonical/jp.ubuntu.com/assets/4356209/41d3f2c2-4806-4e6b-b8c4-4f805d449f8a)
