### PR TITLE
WD-5437 Add acquisition URL field

### DIFF
--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -30,6 +30,7 @@
         <input value="3659" name="formid" type="hidden">
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
         <input type="hidden" name="returnURL" aria-label="returnURL" value="https://jp.ubuntu.com/thank-you">
+        <input type="hidden" name="acquisition_url" aria-label="acquisition_url" value="{{ request.url }}">
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />

--- a/templates/download/thank-you.html
+++ b/templates/download/thank-you.html
@@ -95,6 +95,7 @@
           <input type="hidden" name="Consent_to_Processing__c" value="yes" />
           <input value="3649" name="formid" type="hidden">
           <input type="hidden" name="returnURL" aria-label="returnURL" value="https://jp.ubuntu.com/download?page=thank-you">
+          <input type="hidden" name="acquisition_url" aria-label="acquisition_url" value="{{ request.url }}">
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />

--- a/templates/engage/shared/_form.html
+++ b/templates/engage/shared/_form.html
@@ -43,6 +43,7 @@
         <!-- hidden fields -->
         <input type="hidden" name="formid" value="{{id}}">
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{returnURL}}" />
+        <input type="hidden" name="acquisition_url" aria-label="acquisition_url" value="{{ request.url }}">
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />

--- a/templates/shared/_contact-us-form.html
+++ b/templates/shared/_contact-us-form.html
@@ -71,6 +71,7 @@
           <!-- hidden fields -->
           <input type="hidden" name="formid" value="2549">
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{returnURL}}" />
+          <input type="hidden" name="acquisition_url" aria-label="acquisition_url" value="{{ request.url }}">
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />


### PR DESCRIPTION
## Done

Add acquisition URLs for marketo to obtain the full path.

## QA

- Go to https://jp-ubuntu-com-463.demos.haus/blog/accelerating-the-adoption-of-ai-in-banking-with-mlops-jp
- Submit the newsletter form on the right.
- You should receive the acquisition URL now in Marketo.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5585

## Screenshots

[if relevant, include a screenshot]
