### PR TITLE
Refresh for 23.10

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1,13 +1,14 @@
 latest:
-  slug: LunarLobster
-  name: "Lunar Lobster"
-  short_version: "23.04"
-  full_version: "23.04"
+  slug: ManticMinotaur
+  name: "Mantic Minotaur"
+  short_version: "23.10"
+  full_version: "23.10"
+  desktop_version: "23.10.1" # for 23.10 release only, because Desktop image for 23.10 release has version 23.10.1, while as all other images have version 23.10
   core_version: "22"
-  release_date: "2023年4月"
-  eol: "2024年1月"
+  release_date: "2023年10月"
+  eol: "2024年7月"
   past_eol_date: false
-  release_notes_url: "https://discourse.ubuntu.com/t/lunar-lobster-release-notes/31910"
+  release_notes_url: "https://discourse.ubuntu.com/t/mantic-minotaur-release-notes/35534"
 lts:
   slug: JammyJellyfish
   name: "Jammy Jellyfish"
@@ -31,33 +32,33 @@ openstack_lts:
 
 checksums:
   desktop:
-    "23.04": "a8cd6ccff865e17dd136658f6388480c9a5bc57274b29f7d5bd0ed855a9281a5 *ubuntu-23.04-desktop-amd64.iso"
+    "23.10.1": "3b6c5275366d02160554fa5703add462da3b8ce9be1749f8806e8dbbffaa2b5a *ubuntu-23.10.1-desktop-amd64.iso"
     "22.04.3": "a435f6f393dda581172490eda9f683c32e495158a780b5a1de422ee77d98e909 *ubuntu-22.04.3-desktop-amd64.iso"
     "21.10": "f8d3ab0faeaecb5d26628ae1aa21c9a13e0a242c381aa08157db8624d574b830 *ubuntu-21.10-desktop-amd64.iso"
     "20.04.6": "510ce77afcb9537f198bc7daa0e5b503b6e67aaed68146943c231baeaab94df1 *ubuntu-20.04.6-desktop-amd64.iso"
   live-server:
-    "23.04": "c7cda48494a6d7d9665964388a3fc9c824b3bef0c9ea3818a1be982bc80d346b *ubuntu-23.04-live-server-amd64.iso"
+    "23.10": "d2fb80d9ce77511ed500bcc1f813e6f676d4a3577009dfebce24269ca23346a5 *ubuntu-23.10-live-server-amd64.iso"
     "22.04.3": "a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd *ubuntu-22.04.3-live-server-amd64.iso"
     "21.10": "e84f546dfc6743f24e8b1e15db9cc2d2c698ec57d9adfb852971772d1ce692d4 *ubuntu-21.10-live-server-amd64.iso"
     "20.04.6": "b8f31413336b9393ad5d8ef0282717b2ab19f007df2e9ed5196c13d8f9153c8b *ubuntu-20.04.6-live-server-amd64.iso"
     "18.04.6": "6c647b1ab4318e8c560d5748f908e108be654bad1e165f7cf4f3c1fc43995934 *ubuntu-18.04.6-live-server-amd64.iso"
   desktop-arm64+raspi:
-    "23.04": "c851edd5d05362b7a9fe9a6e44824d89114de2c07b6f08d97ad790f0bafdc9f1 *ubuntu-23.04-preinstalled-desktop-arm64+raspi.img.xz"
+    "23.10": "92cbd905c36114effcec6943d3438845dfac07e3bb238cde4c510b41a71f694b *ubuntu-23.10-preinstalled-desktop-arm64+raspi.img.xz"
     "22.04.3": "d187127752ebf16201102d32c1e7fa7a17532c6b5ccf7b3b08507d0ab0e3416c *ubuntu-22.04.3-preinstalled-desktop-arm64+raspi.img.xz"
     "21.10": "5187d507099f26bc4d8218085109af498fae5ff93b40c668f83bab5c7574d954 *ubuntu-21.10-preinstalled-desktop-arm64+raspi.img.xz"
     "21.04": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
-    "23.04": "cd2a99b065b98078ad2bfec428d5bb876be19c9f5aa8abb8e5dd14125bf611b8 *ubuntu-23.04-preinstalled-server-arm64+raspi.img.xz"
+    "23.10": "81886cefc6b7abe5baf26dbc353bc69924dfc76416c15c3c3d03cf5ba30c90e8 *ubuntu-23.10-preinstalled-server-arm64+raspi.img.xz"
     "22.04.3": "f3842efb3be1be4243c24203bd16e335f155fdbe104b1ed8c5efc548ea478ab0 *ubuntu-22.04.3-preinstalled-server-arm64+raspi.img.xz"
     "21.10": "126f940d3b270a6c1fc5a183ac8a3d193805fead4f517296a7df9d3e7d691a03 *ubuntu-21.10-preinstalled-server-arm64+raspi.img.xz"
     "20.04.5": "44b98acd3fd4379c6b194696520b6aecb2f596b601e43e9b6934c83f0aa61026 *ubuntu-20.04.5-preinstalled-server-arm64+raspi.img.xz"
   server-armhf+raspi:
-    "23.04": "4d6e43707260c3653bdbc30eecd4148b6b314612b8c522de4a60d74fd3df128f *ubuntu-23.04-preinstalled-server-armhf+raspi.img.xz"
+    "23.10": "bab926a3f86837888940db1bbae64b6f7e03b03d044c1669167b6a42fd20cac2 *ubuntu-23.10-preinstalled-server-armhf+raspi.img.xz"
     "22.04.3": "dbab406bfa473ebf95aa2e34e87ebf64467067ffa0478daa85c48e213b925ed6 *ubuntu-22.04.3-preinstalled-server-armhf+raspi.img.xz"
     "21.10": "341593c9607ed20744cd86941d94d73e3ba4f74e8ef2633eec63ce9b0cfac5a1 *ubuntu-21.10-preinstalled-server-armhf+raspi.img.xz"
     "20.04.5": "065c41846ddf7a1c636a1aac5a7d49ebcee819b141f9d57fd586c5f84b9b7942 *ubuntu-20.04.5-preinstalled-server-armhf+raspi.img.xz"
   server-riscv64:
-    "23.04": "774a679251c496426727fcab1355f41f2523845dac405bfe9814a5c4c588df14 *ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz"
+    "23.10": "5c300b9fff78f5d86fec06787e833573220165aeb310a8f1b5c56ca888bc91c2 *ubuntu-23.10-preinstalled-server-riscv64+unmatched.img.xz"
     "22.04.3": "b739d17a3a7f0494b2d804c5f54fd2f303ba665acf353ee3bef78825bfc7b39c *ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz"
     "21.10": "8067892fa627eb219b31dc629f31f3bda6b015dfeabf2fdc9b0ed150bf7984b8 *ubuntu-21.10-preinstalled-server-riscv64+unmatched.img.xz"
   core-22-arm64+raspi:

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -60,7 +60,7 @@
       <h3 class="p-card__title">Ubuntu Desktop {{ releases.latest.full_version }}</h3>
       <div class="p-card__content">
         <p>デスクトップPCおよびノートPC向けのUbuntuオペレーティングシステムの最新バージョンです。Ubuntu {{ releases.latest.full_version }} では、{{ releases.latest.eol }}までの9か月間、セキュリティアップデートおよびメンテナンスアップデートが提供されます</p>
-        <p><a class="p-button row" href="/download/thank-you/?version={{ releases.latest.full_version }}&architecture=amd64&platform=desktop"><span class="p-link--external">ダウンロード</span></a></p>
+        <p><a class="p-button row" href="/download/thank-you/?version={{ releases.latest.desktop_version }}&architecture=amd64&platform=desktop"><span class="p-link--external">ダウンロード</span></a></p>
         <p><a class="p-link--external" href="{{ releases.latest.release_notes_url }}">Ubuntu {{ releases.latest.full_version }} release notes</a></p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- merge releases.yaml from ubuntu.com
- use the "releases.latest.desktop_version" variable for the desktop download url to accommodate 23.10.1

## QA

1. open https://jp.ubuntu.com/download equivalent in the test site
2. double check the latest release is 23.10
3. click the download button for the latest Ubuntu image
4. confirm 23.10.1 will be downloaded

## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[current]
![image](https://github.com/canonical/jp.ubuntu.com/assets/4356209/96beb9b3-a91d-49bd-a3a4-6f61917a23cc)
