### PR TITLE
Refresh for 22.04.4 -- merge releases.yaml from ubuntu.com

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -13,7 +13,7 @@ lts:
   slug: JammyJellyfish
   name: "Jammy Jellyfish"
   short_version: "22.04"
-  full_version: "22.04.3"
+  full_version: "22.04.4"
   release_date: "2022年4月"
   eol: "2027年4月"
   release_notes_url: "https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668"
@@ -33,35 +33,35 @@ openstack_lts:
 checksums:
   desktop:
     "23.10.1": "3b6c5275366d02160554fa5703add462da3b8ce9be1749f8806e8dbbffaa2b5a *ubuntu-23.10.1-desktop-amd64.iso"
-    "22.04.3": "a435f6f393dda581172490eda9f683c32e495158a780b5a1de422ee77d98e909 *ubuntu-22.04.3-desktop-amd64.iso"
+    "22.04.4": "071d5a534c1a2d61d64c6599c47c992c778e08b054daecc2540d57929e4ab1fd *ubuntu-22.04.4-desktop-amd64.iso"
     "21.10": "f8d3ab0faeaecb5d26628ae1aa21c9a13e0a242c381aa08157db8624d574b830 *ubuntu-21.10-desktop-amd64.iso"
     "20.04.6": "510ce77afcb9537f198bc7daa0e5b503b6e67aaed68146943c231baeaab94df1 *ubuntu-20.04.6-desktop-amd64.iso"
   live-server:
     "23.10": "d2fb80d9ce77511ed500bcc1f813e6f676d4a3577009dfebce24269ca23346a5 *ubuntu-23.10-live-server-amd64.iso"
-    "22.04.3": "a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd *ubuntu-22.04.3-live-server-amd64.iso"
+    "22.04.4": "45f873de9f8cb637345d6e66a583762730bbea30277ef7b32c9c3bd6700a32b2 *ubuntu-22.04.4-live-server-amd64.iso"
     "21.10": "e84f546dfc6743f24e8b1e15db9cc2d2c698ec57d9adfb852971772d1ce692d4 *ubuntu-21.10-live-server-amd64.iso"
     "20.04.6": "b8f31413336b9393ad5d8ef0282717b2ab19f007df2e9ed5196c13d8f9153c8b *ubuntu-20.04.6-live-server-amd64.iso"
     "18.04.6": "6c647b1ab4318e8c560d5748f908e108be654bad1e165f7cf4f3c1fc43995934 *ubuntu-18.04.6-live-server-amd64.iso"
   desktop-arm64+raspi:
     "23.10": "92cbd905c36114effcec6943d3438845dfac07e3bb238cde4c510b41a71f694b *ubuntu-23.10-preinstalled-desktop-arm64+raspi.img.xz"
-    "22.04.3": "d187127752ebf16201102d32c1e7fa7a17532c6b5ccf7b3b08507d0ab0e3416c *ubuntu-22.04.3-preinstalled-desktop-arm64+raspi.img.xz"
+    "22.04.4": "9a4dbf8644d96fc55c0214454be8f50cb3cbf8b15d4475bba8f74679e2cd4411 *ubuntu-22.04.4-preinstalled-desktop-arm64+raspi.img.xz"
     "21.10": "5187d507099f26bc4d8218085109af498fae5ff93b40c668f83bab5c7574d954 *ubuntu-21.10-preinstalled-desktop-arm64+raspi.img.xz"
     "21.04": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
     "23.10": "81886cefc6b7abe5baf26dbc353bc69924dfc76416c15c3c3d03cf5ba30c90e8 *ubuntu-23.10-preinstalled-server-arm64+raspi.img.xz"
-    "22.04.3": "f3842efb3be1be4243c24203bd16e335f155fdbe104b1ed8c5efc548ea478ab0 *ubuntu-22.04.3-preinstalled-server-arm64+raspi.img.xz"
+    "22.04.4": "8985915e3840d1e3971780aa160791e0665f64a2ee7e52ef8285c0701a8f6d6b *ubuntu-22.04.4-preinstalled-server-arm64+raspi.img.xz"
     "21.10": "126f940d3b270a6c1fc5a183ac8a3d193805fead4f517296a7df9d3e7d691a03 *ubuntu-21.10-preinstalled-server-arm64+raspi.img.xz"
     "20.04.5": "44b98acd3fd4379c6b194696520b6aecb2f596b601e43e9b6934c83f0aa61026 *ubuntu-20.04.5-preinstalled-server-arm64+raspi.img.xz"
   server-armhf+raspi:
     "23.10": "bab926a3f86837888940db1bbae64b6f7e03b03d044c1669167b6a42fd20cac2 *ubuntu-23.10-preinstalled-server-armhf+raspi.img.xz"
-    "22.04.3": "dbab406bfa473ebf95aa2e34e87ebf64467067ffa0478daa85c48e213b925ed6 *ubuntu-22.04.3-preinstalled-server-armhf+raspi.img.xz"
+    "22.04.4": "27b1697e7aff3d395dfe242755e066a9c8b8d4d7f2ab07195ddf3d704cf40b3f *ubuntu-22.04.4-preinstalled-server-armhf+raspi.img.xz"
     "21.10": "341593c9607ed20744cd86941d94d73e3ba4f74e8ef2633eec63ce9b0cfac5a1 *ubuntu-21.10-preinstalled-server-armhf+raspi.img.xz"
     "20.04.5": "065c41846ddf7a1c636a1aac5a7d49ebcee819b141f9d57fd586c5f84b9b7942 *ubuntu-20.04.5-preinstalled-server-armhf+raspi.img.xz"
   server-riscv64:
     "23.10": "5c300b9fff78f5d86fec06787e833573220165aeb310a8f1b5c56ca888bc91c2 *ubuntu-23.10-preinstalled-server-riscv64+unmatched.img.xz"
-    "22.04.3": "b739d17a3a7f0494b2d804c5f54fd2f303ba665acf353ee3bef78825bfc7b39c *ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz"
+    "22.04.4": "fc86d5f6e1ddb1cb7f59255b4adc5872a103ba61fd6746a0fc1994d850f663c8 *ubuntu-22.04.4-preinstalled-server-riscv64+unmatched.img.xz"
     "21.10": "8067892fa627eb219b31dc629f31f3bda6b015dfeabf2fdc9b0ed150bf7984b8 *ubuntu-21.10-preinstalled-server-riscv64+unmatched.img.xz"
   core-22-arm64+raspi:
-    "22": "374697bd7324f10ff3c00007b75ca42885aff161cbddb63b1d14bc1551e69ce2 *ubuntu-core-22-arm64+raspi.img.xz"
+    "22": "7639f5ff8bb5c0d4cf0e86041b56dd0daa27a3d05b475a9a85c5d085b561fb8e *ubuntu-core-22-arm64+raspi.img.xz"
   core-22-armhf+raspi:
-    "22": "e495c578f6279d0bbb13437cf04574142013ec77d61855e8bc7f51919dc88739 *ubuntu-core-22-armhf+raspi.img.xz"
+    "22": "4c4b3958626611aff85bfa5873c45ad22fdf7642be868b5722900fa88e6fca86 *ubuntu-core-22-armhf+raspi.img.xz"


### PR DESCRIPTION
Equivalent to https://github.com/canonical/ubuntu.com/pull/13604

## Done

merge releases.yaml from ubuntu.com

## QA

- Go to https://jp.ubuntu.com/download in the demo site
- Click 22.04.4 LTS download link for both Desktop and Server
- Confirm the download starts
