### PR TITLE
WD-14011 - change footer microcloud link

### DIFF
--- a/templates/_base/footer.html
+++ b/templates/_base/footer.html
@@ -12,7 +12,7 @@
             <a href="/kubernetes">Kubernetes</a>
           </li>
           <li class="p-inline-list__item">
-            <a href="https://canonical.com/microcloud">MicroCloud</a>
+            <a href="/microcloud">MicroCloud</a>
           </li>
           <li class="p-inline-list__item">
             <a href="/enterprise-support">商用サポート</a>


### PR DESCRIPTION
## Done

Changed footer Microcloud link to jp.ubuntu.com/microcloud

## QA

Check that the footer link is correct

## Issue / Card
[WD-14011](https://warthogs.atlassian.net/browse/WD-14011)


[WD-14011]: https://warthogs.atlassian.net/browse/WD-14011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ