### PR TITLE
fix: Repair the URL and improve the image size on the AI/ML page

### DIFF
--- a/templates/ai-ml.html
+++ b/templates/ai-ml.html
@@ -308,11 +308,10 @@
       </div>
       <div class="col">
         <div class="p-image-container u-hide--small">
-          {{ image(url="
-                    https://assets.ubuntu.com/v1/a7410cea-Canonical%20AI%20ML%20Illustrations%20v5-08.png",
+          {{ image(url="https://assets.ubuntu.com/v1/a7410cea-Canonical%20AI%20ML%20Illustrations%20v5-08.png",
                     alt="",
-                    width="8000",
-                    height="4500",
+                    width="675",
+                    height="380",
                     hi_def=True,
                     attrs={"class": "p-image-container__image"},
                     loading="lazy") | safe


### PR DESCRIPTION
## Done

- Removed the whitespaces before the URL in the image template tag
- Reduced the size of the image to the size we rendered, which dropped the image size from >600kb to <50kb 

## QA

1. Open the demo
2. Go to /ai-ml
3. Scroll down to the section in the screenshot section
4. Check image loads
5. See that the file size has been reduced without compromising the quality

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/c376f2a6-b141-49df-82cb-fb3d967f01f7) | ![image](https://github.com/user-attachments/assets/90ff95fb-933d-4e42-a5e1-ab77cf7bf4ad) |

