### PR TITLE
feat: Add thank you text to engage pages

### DIFF
--- a/templates/engage/shared/thank-you.html
+++ b/templates/engage/shared/thank-you.html
@@ -24,13 +24,14 @@
        <h1 class="p-heading--2">ありがとうございました！</h1>
     </div>
   </div>
-</div>
 </section>
 
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
-      {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
+      {% if thank_you_text %}
+        {{ thank_you_text }}
+      {% elif 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
       <p>
         きみの{{ resource_name }}ダウンロード中です...
       </p>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -94,12 +94,15 @@ def engage_thank_you(engage_pages):
                 # we can only fit 3 related posts, no need to finish the loop
                 break
 
+        thank_you_text = metadata.get("thank_you_text", None)
+
         return flask.render_template(
             "engage/shared/thank-you.html",
             request_url=flask.request.referrer,
             resource_name=metadata["type"],
             resource_url=metadata["resource_url"],
             related=related,
+            thank_you_text=thank_you_text,
         )
 
     return render_template


### PR DESCRIPTION
## Done

- Add `thank_you_text` on engage pages thank you pages
- Optional field, otherwise it shows the default thank you text

## QA

- Go to https://jp-ubuntu-com-498.demos.haus/engage/japan-it-week-live-demo-jp/thank-you
- See that the thank you text matches value on discourse metadata https://discourse.ubuntu.com/t/jp-evt-japan-it-week-live-demo-tour-2025/57357

## Issue / Card

Fixes [WD-20430](https://warthogs.atlassian.net/browse/WD-20430)

## Screenshots

[if relevant, include a screenshot]


[WD-20430]: https://warthogs.atlassian.net/browse/WD-20430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ