### PR TITLE
feat: Retain original thank you info with text

### DIFF
--- a/templates/engage/shared/thank-you.html
+++ b/templates/engage/shared/thank-you.html
@@ -31,10 +31,11 @@
     <div class="col-8">
       {% if thank_you_text %}
         {{ thank_you_text }}
-      {% elif 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
-      <p>
-        きみの{{ resource_name }}ダウンロード中です...
-      </p>
+      {% endif %}         
+      {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
+        <p>
+          きみの{{ resource_name }}ダウンロード中です...
+        </p>
       <p>
         <a class="p-button--positive" href="{{ resource_url }}">ダウンロード中</a>
       </p>


### PR DESCRIPTION
## Done

- Retain original thank you info if `thank_you_text` is present

## QA

- Go to /engage/japan-it-week-live-demo-jp/thank-you
- See that the `thank_you_text` is present, together with original thank you text and CTA

## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
