### PR TITLE
Skip checking compressed CSS files content for LinkChecker

### DIFF
--- a/.github/workflows/live-links.yml
+++ b/.github/workflows/live-links.yml
@@ -48,8 +48,6 @@ jobs:
           warnings=0
           ignoreerrors=
           ^http?s://.* ^.*(471|500|503|504|400|403|521|401)
-          nofollow=
-            https://jp.ubuntu.com/static/css/styles.css
           EOF
 
       - name: Run linkchecker for 404 errors only

--- a/.github/workflows/live-links.yml
+++ b/.github/workflows/live-links.yml
@@ -40,12 +40,16 @@ jobs:
             https://www.xilinx.com/applications/*
             https://player.vimeo.com/video/*
             ^https://assets\.ubuntu\.com/?$
+          nofollow=
+            https://jp.ubuntu.com/static/css/styles.css
 
           [output]
           status=0
           warnings=0
           ignoreerrors=
           ^http?s://.* ^.*(471|500|503|504|400|403|521|401)
+          nofollow=
+            https://jp.ubuntu.com/static/css/styles.css
           EOF
 
       - name: Run linkchecker for 404 errors only


### PR DESCRIPTION
Problem:
The linkchecker script crashed because it attempted to decode the CSS content as plain UTF-8 text before decompression, leading to a UnicodeDecodeError.
Example [here](https://github.com/canonical/jp.ubuntu.com/actions/runs/15726616711/job/44317774221)

## Done
This PR addresses the UnicodeDecodeError encountered when running linkchecker against the  compressed CSS file (https://jp.ubuntu.com/static/css/styles.css) by making the bot only check that the file exist and not try to read it's content.

Ticket # [WD-23019](https://warthogs.atlassian.net/browse/WD-23019)


[WD-23019]: https://warthogs.atlassian.net/browse/WD-23019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ