### PR TITLE
feat: Add calendly widget

### DIFF
--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -87,7 +87,12 @@
     </div>
     {% endif %}
   </div>
-
+  
+  <!-- calendly -->
+  {% if "calendly_url" in metadata and metadata.calendly_url != "" %}
+    <div class="calendly-inline-widget" data-url="{{ metadata.calendly_url }}" style="min-width:320px;height:700px;"></div>
+    <script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js" async></script>
+  {% endif %}
 </section>
 
 {% if "webinar_code" in metadata and metadata.webinar_code != "" %}


### PR DESCRIPTION
## Done

- Add widget for calendly URL

## QA

- Go to https://jp-ubuntu-com-505.demos.haus/engage/livechat-day-2025-jp
- Scroll down, see that calendly widget is present

## Issue / Card

[WD-23120](https://warthogs.atlassian.net/browse/WD-23120)

## Screenshots

[if relevant, include a screenshot]


[WD-23120]: https://warthogs.atlassian.net/browse/WD-23120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ