### PR TITLE
feat: add partner consent checkbox and form CTA text

### DIFF
--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -7,6 +7,10 @@
 {% block meta_description %}{{metadata['subtitle']}}{% endblock %}
 {% block meta_image %}{{metadata['meta_image']}}{% endblock %}
 
+{% block head_extra %}
+  <meta name="discourse-url" value="{{ metadata['topic_path'] }}" />
+{% endblock %}
+
 {% block meta_copydoc %}{metadata["meta_copydoc]}{% endblock meta_copydoc %}
 
 {% block outer_content %}

--- a/templates/engage/shared/_form.html
+++ b/templates/engage/shared/_form.html
@@ -25,10 +25,20 @@
         <ul class="p-list">
           <li class="p-list__item">
             <label class="p-checkbox">
-              <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" type="checkbox">
+              <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox" />
               <span class="p-checkbox__label" id="canonicalUpdatesOptIn">不定期配信のニュースメールを希望の方はこちらをチェックください。</span>
             </label> <!-- I would like to receive occasional news from Canonical by email. -->
           </li>
+          {% if "partner_permission" in metadata %}
+            <li>
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" name="Partner_Marketing_Opt_in__c" aria-label="Partner Permission" value="true" type="checkbox" />
+                <span class="p-checkbox__label" id="Partner_Marketing_Opt_in__c">
+                  Canonical または指定された共同主催者から、イベント情報やニュース、製品アップデートなどをご案内する場合があります。受信をご希望の場合は、チェックボックスにご選択ください。個人データの取り扱いについては <a href="https://canonical.com/legal/data-privacy/newsletter">Canonical のプライバシー通知</a>をご覧ください。ご同意後も、メール下部の「購読解除」からいつでも受信を停止できます。
+                </span>
+              </label>
+            </li>
+          {% endif %}
           <li class="p-list__item">
             <p><a href="https://ubuntu.com/legal" target="_blank">記載頂いた情報はCanonicalの個人情報保護ポリシーに基づき管理いたします。</a>.</p>
           </li> <!-- All information provided will be handled in accordance with the Canonical privacy policy -->
@@ -36,7 +46,7 @@
         <ul class="p-list u-no-margin--bottom">
           <li class="p-list__item">
             <button type="submit" class="p-button--positive">
-              ダウンロード
+              {% if metadata['form_cta'] != '' %}{{ metadata['form_cta'] }}{% else %}ダウンロード{% endif %}
             </button>
           </li> <!-- Submit -->
         </ul>


### PR DESCRIPTION
## Done

- Add partner consent checkbox
- Add functionality to modify form CTA text
- Added `discourse-url` meta tag on engage pages

## QA

- Go to https://jp-ubuntu-com-509.demos.haus/engage/canonical-day-tokyo-2025
- Check that the field for partner consent is present
- Check that the form submission button is similar to the `form_cta` text on [discourse](https://discourse.ubuntu.com/t/event-canonical-day-tokyo-2025/66543)
- Submit form
- See that it goes through successfully

## Issue / Card

[WD-25655](https://warthogs.atlassian.net/browse/WD-25655)

## Screenshots

[if relevant, include a screenshot]


[WD-25655]: https://warthogs.atlassian.net/browse/WD-25655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ